### PR TITLE
Update link to the example

### DIFF
--- a/_layouts/learn.html
+++ b/_layouts/learn.html
@@ -105,7 +105,7 @@ title: Learn
 		</div>
 		<div class="row">
 			<div class="column one-third">
-				{% include card.html title="Examples" body="A selection of code samples and examples to learn from." link="/examples/basics/simple_move" min-height="250px" icon="/images/icons/icons-learn-export_ic-learn-toolbox.svg" %}
+				{% include card.html title="Examples" body="A selection of code samples and examples to learn from." link="/examples/animation/basic_tween" min-height="250px" icon="/images/icons/icons-learn-export_ic-learn-toolbox.svg" %}
 			</div>
 			<div class="column one-third">
 				{% include card.html title="API Reference" body="Reference documentation to all Defold Lua and C++ extension APIs." link="/ref/stable/go" min-height="250px" icon="/images/icons/icons-learn-export_ic-learn-apiref.svg" %}


### PR DESCRIPTION
The link was wrong, i.e. the page was missing.