### PR TITLE
Add arm64-macos download links

### DIFF
--- a/css/defold.scss
+++ b/css/defold.scss
@@ -244,6 +244,16 @@
 select {
 	overflow:auto;
 }
+.download-select {
+	background: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='100' height='100' fill='%23FFFFFF'><polygon points='0,0 100,0 50,50'/></svg>") no-repeat;
+	background-size: 10px;
+	background-position: calc(100% - 10px) calc(50% + 3px);
+    -moz-appearance: none; 
+    -webkit-appearance: none;
+    appearance: none;
+	overflow: hidden;
+	width: 200px;
+}
 
 mark {
 	background: var(--defold-blue);

--- a/download.html
+++ b/download.html
@@ -12,7 +12,13 @@ after: [subscribe.html, learn_section.html, donors_and_partners.html]
 	<div class="columns four">
 		<span class="icon-apple blue-text" style="font-size: 50px"></span>
 		<p>Requires macOS 11 Big Sur or newer</p>
-		{% include primary_button.html link="https://d.defold.com/editor2/channels/editor-alpha/Defold-x86_64-macos.dmg" text="Download for Mac" %}
+		<form style="margin: 0;">
+			<select name="select" class="button primary download-select" onChange="window.open(this.options[this.selectedIndex].value,'_blank')">
+				<option selected disabled hidden>Download for Mac</option>
+				<option value="https://d.defold.com/editor2/channels/editor-alpha/Defold-arm64-macos.dmg">Apple Silicon Mac</option>
+				<option value="https://d.defold.com/editor2/channels/editor-alpha/Defold-x86_64-macos.dmg">Intel Mac</option>
+			</select>
+		</form>
 		<p><a href="https://forum.defold.com/c/releasenotes" target="_blank">Release notes</a></p>
 	</div>
 	<div class="columns four">


### PR DESCRIPTION
We can't merge it yet because https://d.defold.com/editor2/channels/editor-alpha/Defold-arm64-macos.dmg is not set right now.