### PR TITLE
Add an RSS feed link

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -55,6 +55,9 @@
 <meta name="keywords" content="defold, gameengine, game-engine, game-development, game-dev, gamedev, open-source, opensource, crossplatform, cross-platform, free, nintendo-switch, console, html5, web, android, ios, desktop" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 
+<!-- RSS FEED -->
+<link rel="alternate" type="application/rss+xml" title="{{ site.name }}" href="/feed.xml" />
+
 <!-- OPEN GRAPH -->
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ site.url }}{{ page.url }}">


### PR DESCRIPTION
An RSS feed wasn't being found for me when trying to subscribe to the blog on Feedly.

The feed is located at https://defold.com/feed.xml but Feedly wasn't picking it up for some reason.

I've added a link to the head so it should be found on any page now.