### PR TITLE
Remove extra slash from feed URLs

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -13,8 +13,8 @@ layout: none
 			<title>{{ post.title | xml_escape }}</title>
 			<description>{{ post.content | xml_escape }}</description>
 			<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-			<link>{{ site.url }}/{{ post.url }}</link>
-			<guid isPermaLink="true">{{ site.url }}/{{ post.url }}</guid>
+			<link>{{ site.url }}{{ post.url }}</link>
+			<guid isPermaLink="true">{{ site.url }}{{ post.url }}</guid>
 		</item>
 		{% endfor %}
 	</channel>


### PR DESCRIPTION
Links from the feed page have an extra slash in them: https://defold.com//2023/09/18/Working-with-both-public-and-private-repos/

They still work but should be updated. It looks like `{{ post.url }}` already has the slash in it.