### PR TITLE
Consistent indentation on Examples pages (tab size of 4 spaces)

### DIFF
--- a/_layouts/example.html
+++ b/_layouts/example.html
@@ -53,7 +53,6 @@ layout: page
 				{%- if page.scripts.size > 0 -%}
 				<h4>Scripts</h4>
 				{% endif %}
-
 				{% assign scripts = page.scripts | split: "," %}
 				{% assign collection = page.collection %}
 				{% for script in scripts %}

--- a/_layouts/example.html
+++ b/_layouts/example.html
@@ -53,17 +53,17 @@ layout: page
 				{%- if page.scripts.size > 0 -%}
 				<h4>Scripts</h4>
 				{% endif %}
+
 				{% assign scripts = page.scripts | split: "," %}
 				{% assign collection = page.collection %}
 				{% for script in scripts %}
 				<p>{{ script }}</p>
-{% comment %}
-	The indentation of the following "highlight" block is intentional
-	so that there are no extra spaces in the generated <code></code> block
-{% endcomment %}
-{% highlight lua %}
-{% include examples/{{ collection}}/{{ script | lstrip | replace: ".script", "_script.md" | replace: ".gui_script", "_gui_script.md" }} %}
-{% endhighlight %}
+				{% comment %}
+					Assign content of the script into a variable and then
+					replace tabs with 4 slaces to have consistent indentations
+				{% endcomment %}
+				{% capture script_content %}{% include examples/{{ collection }}/{{ script | lstrip | replace: ".script", "_script.md" | replace: ".gui_script", "_gui_script.md" }} %}{% endcapture %}
+				{% highlight lua %}{{ script_content | replace: "	", "    " }}{% endhighlight %}
 				{% endfor %}
 			</div>
 			<div class="columns two">

--- a/_layouts/example.html
+++ b/_layouts/example.html
@@ -59,7 +59,7 @@ layout: page
 				<p>{{ script }}</p>
 				{% comment %}
 					Assign content of the script into a variable and then
-					replace tabs with 4 slaces to have consistent indentations
+					replace each tab with 4 spaces to have consistent indentations
 				{% endcomment %}
 				{% capture script_content %}{% include examples/{{ collection }}/{{ script | lstrip | replace: ".script", "_script.md" | replace: ".gui_script", "_gui_script.md" }} %}{% endcapture %}
 				{% highlight lua %}{{ script_content | replace: "	", "    " }}{% endhighlight %}


### PR DESCRIPTION
# Problem

For code blocks on Manuals pages tab size of 4/2 spaces is used, on API Reference pages - 4 spaces.
The Examples pages however use tabs.

Manuals - 4 spaces (https://defold.com/manuals/message-passing/#message-chains):
(looks good)
![image](https://github.com/defold/defold.github.io/assets/7230306/71ebf461-d7bd-4b7f-a07b-98fd632ac8a7)

Examples - tabs (https://defold.com/examples/basics/message_passing/):
(tabs take a bit too much space)
![image](https://github.com/defold/defold.github.io/assets/7230306/9ba6a77f-a164-4f5a-9bff-82b6554361c3)

Examples - tabs and spaces (https://defold.com/examples/basics/parent_child/):
(it looks even worse when there is a mix of both)
![image](https://github.com/defold/defold.github.io/assets/7230306/ea4c9d63-76e9-4716-ac3b-cd11405b1f65)

# Fix

There are a lot of examples and they could be written by different people so it will take lot of efforts to fix and maintain consistent indentations manually.
The fix replaces each tab with 4 spaces when html is generated.

# Demo

Examples - 4 spaces (instead of tabs):
![image](https://github.com/defold/defold.github.io/assets/7230306/f760d35d-1c7a-45fa-a76a-6a3fdf203832)

Examples - 4 spaces (instead of tabs and spaces):
![image](https://github.com/defold/defold.github.io/assets/7230306/c987ba52-5cbe-4526-8a43-06a437cbde22)
