### PR TITLE
Copy to clipboard icon for code snippets

### DIFF
--- a/_includes/copy-icon-for-code-snippets.html
+++ b/_includes/copy-icon-for-code-snippets.html
@@ -15,12 +15,12 @@
 			}
 		});
 
-		function onDocumentLoad(initialize) {
+		function onDocumentLoad(callback) {
 			var hasRun = false;
 			var loadHandler = function (evt) {
 				if (hasRun) return;
 				hasRun = true;
-				initialize();
+				callback();
 			};
 
 			document.addEventListener('DOMContentLoaded', loadHandler, false);

--- a/_includes/copy-icon-for-code-snippets.html
+++ b/_includes/copy-icon-for-code-snippets.html
@@ -1,0 +1,31 @@
+<script src="/js/clipboard.js"></script>
+
+<script>
+	(function() {
+		onDocumentLoad(function() {
+			var elementsWithCode = document.querySelectorAll([
+				'pre.highlight', 			// Manuals
+				'div.codehilite pre', 		// API Reference
+				'figure.highlight > pre', 	// Examples
+			].join(','));
+			for (var el of elementsWithCode) {
+				var container = createCopyToClipboardButtonFor(el);
+				el.parentNode.style.position = 'relative';
+				el.parentNode.appendChild(container);
+			}
+		});
+
+		function onDocumentLoad(initialize) {
+			var hasRun = false;
+			var loadHandler = function (evt) {
+				if (hasRun) return;
+				hasRun = true;
+				console.log('BINGO');
+				initialize();
+			};
+
+			document.addEventListener('DOMContentLoaded', loadHandler, false);
+			window.addEventListener('load', loadHandler, false); // older browsers
+		}
+	})();
+</script>

--- a/_includes/copy-icon-for-code-snippets.html
+++ b/_includes/copy-icon-for-code-snippets.html
@@ -20,7 +20,6 @@
 			var loadHandler = function (evt) {
 				if (hasRun) return;
 				hasRun = true;
-				console.log('BINGO');
 				initialize();
 			};
 

--- a/_layouts/api.html
+++ b/_layouts/api.html
@@ -95,3 +95,4 @@ layout: base
 </div>
 
 {%- include marksearchhits.html div="apicontent" -%}
+{%- include copy-icon-for-code-snippets.html -%}

--- a/_layouts/example.html
+++ b/_layouts/example.html
@@ -77,3 +77,5 @@ layout: page
 		</div>
 	</div>
 </div>
+
+{%- include copy-icon-for-code-snippets.html -%}

--- a/_layouts/manual.html
+++ b/_layouts/manual.html
@@ -106,3 +106,4 @@ layout: page
 </div>
 
 {%- include marksearchhits.html div="manual" -%}
+{%- include copy-icon-for-code-snippets.html -%}

--- a/_scss/defold.scss
+++ b/_scss/defold.scss
@@ -15,6 +15,7 @@
 	--defold-blue-darkest: #1a70eb;
 
 	--defold-orange: #fd6623;
+	--defold-green: #57ab5a;
 }
 
 /*******************************************************************************
@@ -88,6 +89,16 @@
 		}
 		img.logo-hor-classic-160 {
 			content: url("/images/logo/defold/logo_with_text/logo-hor-classic-white-160.png");
+		}
+		.clipboard-button {
+			&:hover {
+				background-color: var(--grey);
+				border-color: var(--lighter);
+			}
+			&:active {
+				background-color: var(--dark);
+				border-color: var(--light);
+			}
 		}
 	}
 
@@ -1161,8 +1172,9 @@ ul.checkmark li:before {
 	display: inline-block;
 }
 
-
-/* Search */
+/*******************************************************************************
+* Search
+******************************************************************************/
 
 #searchresults {
 	.spinner {
@@ -1172,4 +1184,53 @@ ul.checkmark li:before {
 	.search-text {
 		vertical-align: middle;
 	}
+}
+
+/*******************************************************************************
+* Copy code snippets to clipboard
+******************************************************************************/
+
+.clipboard-container {
+	position: absolute;
+	top: 0;
+	right: 0;
+	padding: 0.7rem 1rem;
+}
+.clipboard-button {
+	position: relative;
+	border: 1px solid var(--light);
+	padding: 0.4rem 0.6rem;
+	border-radius: 4px;
+	font-size: 12px;
+	line-height: 20px;
+	white-space: nowrap;
+	cursor: pointer;
+	transition: 80ms cubic-bezier(0.33, 1, 0.68, 1);
+  	transition-property: color, background-color, border-color;
+
+	&:hover {
+		background-color: var(--lightest);
+  		border-color: var(--lighter);
+		transition-duration: .1s;
+	}
+	&:active {
+		background-color: var(--almostlightest);
+  		border-color: var(--lighter);
+		transition: none;
+	}
+
+	&.clipboard-copy-success {
+		border-color: var(--defold-green) !important;
+		color: var(--defold-green) !important;
+		.clipboard-copy-icon { display: none; }
+		.clipboard-check-icon { display: inline-block; }
+	}
+
+	svg {
+		overflow: visible !important;
+		vertical-align: text-bottom;
+		fill: currentColor;
+	}
+
+	.clipboard-check-icon { display: none; }
 }

--- a/_scss/fruity.scss
+++ b/_scss/fruity.scss
@@ -13,12 +13,16 @@
 }
 
 div.codehilite {
-	padding-left: 2rem;
-	padding-right: 2rem;
-	padding-top: 1rem;
 	padding-bottom: 1rem;
+	margin-top: 2rem;
 	margin-bottom: 1rem;
 	font-size: smaller;
+	max-width: 1000px;
+
+	/* fix copy icon position for code snippets with a single line */
+	.clipboard-container {
+		padding: 0.5rem 0.6em;
+	}
 }
 .codehilite .hll { background-color: #333333 }
 .codehilite  { background: var(--background); color: var(--text) }

--- a/js/clipboard.js
+++ b/js/clipboard.js
@@ -1,0 +1,67 @@
+function createCopyToClipboardButtonFor(codeElement) {
+    var container = document.createElement('div');
+    container.classList.add('clipboard-container');
+    var button = document.createElement('div');
+    container.appendChild(button);
+    button.classList.add('clipboard-button');
+    button.onclick = copyToClipboardAndAnnounce(codeElement);
+    button.innerHTML =
+        // MIT license of the icons: https://github.com/primer/octicons/blob/main/LICENSE
+        '<svg class="clipboard-copy-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z"></path><path d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z"></path></svg>' +
+        '<svg class="clipboard-check-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16"><path d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z"></path></svg>';
+    return container;
+
+    ////////////////////////////////
+
+    function copyToClipboardAndAnnounce(codeElement) {
+        var timeout;
+        return function () {
+            var button = this;
+            if (timeout) return; // ignore multiple clicks
+            
+            copyNode(codeElement, {
+                success: showCheckIconAndThenReset(button),
+                error: logError(),
+            });
+        }
+    
+        function showCheckIconAndThenReset(button) {
+            return () => {
+                button.classList.add('clipboard-copy-success');
+                timeout = setTimeout(() => {
+                    button.classList.remove('clipboard-copy-success');
+                    timeout = null;
+                }, 2000);
+            };
+        }
+    }
+    
+    function copyNode(node, callbacks) {
+        var resolve = callbacks.success;
+        var reject = callbacks.error
+    
+        // copy in modern browsers
+        if ('clipboard' in navigator) {
+            var textToCopy = node.textContent && node.textContent.trim() || '';
+            return navigator.clipboard.writeText(textToCopy).then(resolve).catch(reject);
+        }
+    
+        // copy in older browsers
+        var selection = getSelection();
+        if (selection == null)
+            return reject();
+        selection.removeAllRanges();
+        var range = document.createRange();
+        range.selectNodeContents(node);
+        selection.addRange(range);
+        document.execCommand('copy');
+        selection.removeAllRanges();
+        return resolve();
+    }
+    
+    function logError() {
+        return () => {
+            console.error('Failed to copy code to clipboard');
+        };
+    }
+}


### PR DESCRIPTION
Closes https://github.com/defold/defold.github.io/issues/81

## Changes

- the copy icons are added to the DOM after page loads on Manuals, API Reference, Examples
- limit max width of code examples on API Reference so that users could notice the copy icon

Icons are taken from https://github.com/primer/octicons (MIT license). I added link to the license into clipboard.js but not sure if that is enough.

Should be cross-browser. Tested in Firefox (mac), Safari (mac), Chrome (mac).

## Demo

https://github.com/defold/defold.github.io/assets/7230306/8ed9c2da-a549-4371-a9a5-1c8d02c84985