### PR TITLE
A few fixes for dark mode

### DIFF
--- a/_includes/card.html
+++ b/_includes/card.html
@@ -18,7 +18,9 @@
 		<div class="row">
 		{%- if include.icon -%}
 			<div class="columns two">
-				<span class="icon" style="zoom: {{ include.zoom }};"><img src="{{ include.icon }}" alt="{{ include.icon_alt }}"/></span>
+				<span class="icon" style="zoom: {{ include.zoom }};">
+					{% include_relative {{include.icon}} %}
+				</span>
 			</div>
 			<div class="columns ten">
 				<h5 class="left">{{ include.title }}</h5>

--- a/_includes/learn_card.html
+++ b/_includes/learn_card.html
@@ -1,6 +1,13 @@
 <div class='card left compact clickable'>
 <div class="center" style="padding-bottom: 1em;">
-<a href="{{ include.link }}"><img src="{{ include.image }}" style="max-height: 8em;"/></a>
+<a href="{{ include.link }}">
+    {% assign image_extension = include.image | split:'.' | last %}
+    {%- if image_extension == "svg" -%}
+        <span class="icon">{% include_relative {{include.image}} %}</span>
+    {%- else -%}
+        <img src="{{ include.image }}" style="max-height:8em;border-radius:4px;"/>
+    {%- endif -%}
+</a>
 </div>
 <div>
 <a href="{{ include.link }}"><h5>{{ include.title }}</h5></a>

--- a/_includes/learn_section.html
+++ b/_includes/learn_section.html
@@ -1,5 +1,5 @@
-<div class="section hero blue learn-section">
-<div class="dark:darken-10" style="background-image: url('/images/BG-stripes-left.svg')">
+<div class="blue learn-section">
+<div class="section hero dark:darken-10" style="background-image: url('/images/BG-stripes-left.svg')">
 <div class="container">
 <div class="row center">
 <h1>Learn Defold</h1>

--- a/_includes/learn_section.html
+++ b/_includes/learn_section.html
@@ -1,4 +1,4 @@
-<div class="blue learn-section">
+<div class="blue">
 <div class="section hero dark:darken-10" style="background-image: url('/images/BG-stripes-left.svg')">
 <div class="container">
 <div class="row center">

--- a/_includes/learn_section.html
+++ b/_includes/learn_section.html
@@ -1,5 +1,5 @@
-
-<div class="section hero blue" style="background-image: url('/images/BG-stripes-left.svg')">
+<div class="section hero blue learn-section">
+<div class="dark:darken-10" style="background-image: url('/images/BG-stripes-left.svg')">
 <div class="container">
 <div class="row center">
 <h1>Learn Defold</h1>
@@ -25,6 +25,7 @@
 {% include card.html title="Forum" body="Stuck? Not for long! Talk to the Defold team and our fantastic developer community." link="https://forum.defold.com" icon="/images/icons/icons-learn-export_ic-learn-forum.svg" %}
 </div>
 <div class="columns two"><br/></div>
+</div>
 </div>
 </div>
 </div>

--- a/_layouts/learn.html
+++ b/_layouts/learn.html
@@ -3,7 +3,7 @@ layout: page
 title: Learn
 ---
 
-<div class="section hero center blackwhite" style='background-image: url("/images/hero/testimonials-background-0.5x.png");'>
+<div class="section hero center blackwhite dark:darken-10" style='background-image: url("/images/hero/testimonials-background-0.5x.png");'>
 	<div class="container">
 		<div class="row">
 			<div class="column one-half left">

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,7 +1,7 @@
 ---
 layout: page
 ---
-<div class="section lightest">
+<div class="section lightest dark:dark">
 	<div class="container">
 		<div class="row">
 			<div class="columns ten">

--- a/_scss/defold.scss
+++ b/_scss/defold.scss
@@ -28,14 +28,6 @@
 		background-color: rgba(0, 0, 0, 0.10);
 	}
 
-	.learn-section {
-		padding: 0;
-
-		& > div {
-			padding: 8rem 0 7rem;
-		}
-	}
-
 	.dark\:dark {
 		background-color: var(--dark) !important;
 		color: var(--lighter) !important;

--- a/_scss/defold.scss
+++ b/_scss/defold.scss
@@ -23,6 +23,19 @@
 ******************************************************************************/
 
 .dark-mode {
+	.dark\:darken-10 {
+		background-blend-mode: darken;
+		background-color: rgba(0, 0, 0, 0.10);
+	}
+
+	.learn-section {
+		padding: 0;
+
+		& > div {
+			padding: 8rem 0 7rem;
+		}
+	}
+
 	.dark\:dark {
 		background-color: var(--dark) !important;
 		color: var(--lighter) !important;
@@ -1047,6 +1060,12 @@ ul.checkmark li:before {
 }
 .card .icon img {
 	vertical-align: bottom;
+}
+.card .icon svg path {
+	fill: currentColor !important;
+}
+.card.compact .icon svg {
+	max-height: 8em;
 }
 .card h5 {
 	margin-bottom: 0;

--- a/tutorials.html
+++ b/tutorials.html
@@ -4,7 +4,7 @@ title: Defold tutorials
 nav: floating
 ---
 
-<div class="section hero center blackwhite" style='background-image: url("/images/hero/testimonials-background-0.5x.png");'>
+<div class="section hero center blackwhite dark:darken-10" style='background-image: url("/images/hero/testimonials-background-0.5x.png");'>
 	<div class="container">
 		<div class="row">
 			<div class="column one-half left">

--- a/videos.html
+++ b/videos.html
@@ -4,7 +4,7 @@ title: Defold videos
 nav: floating
 ---
 
-<div class="section hero center blackwhite" style='background-image: url("/images/hero/testimonials-background-0.5x.png");'>
+<div class="section hero center blackwhite dark:darken-10" style='background-image: url("/images/hero/testimonials-background-0.5x.png");'>
 	<div class="container">
 		<div class="row">
 			<div class="column one-half left">


### PR DESCRIPTION
# Changes

## fix blog posts to be dark in dark mode

<img width="613" alt="image" src="https://github.com/defold/defold.github.io/assets/7230306/4327bb56-42b9-4642-a2e4-56a35f3ca14e">

## 10% darker header image on Learn, Tutorials, Videos pages

![image](https://github.com/defold/defold.github.io/assets/7230306/2781db54-6591-4d23-94a6-c40f5b42f9bc)

## 10% darker "Learn Defold" section on the front page

![image](https://github.com/defold/defold.github.io/assets/7230306/83fccf7e-01ec-42f8-9f90-5823a76478b9)

## fix svg icons color on Tutorials page

Render `<svg>` on the page instead of `<img>`. `{% include ... %}` looks for files in the `_includes` folder, because of that `{% include_relative ... %}` is used instead to be able to include `/images/icons` without copying them into `_includes`.

![image](https://github.com/defold/defold.github.io/assets/7230306/2e695940-ae01-4eac-8131-f3ebe5009c4c)

## fix svg icons color on Learn page

![image](https://github.com/defold/defold.github.io/assets/7230306/9d607483-9d9c-43e8-a2a4-b21f5866ab33)

## rounded images on Tutorials page

IMO it looks a tad nicer

<img width="370" alt="image" src="https://github.com/defold/defold.github.io/assets/7230306/a09f22bb-c703-4155-b587-5f9e8c359b14">