### PR TITLE
Fix background color of code snippets with horizontal scrolling

### DIFF
--- a/_scss/skeleton.scss
+++ b/_scss/skeleton.scss
@@ -316,7 +316,7 @@ code {
   border-radius: 4px; }
 pre > code {
   display: block;
-	overflow: auto; // fix background color for code blocks with horizontal scrolling
+  overflow: auto; // fix background color for code blocks with horizontal scrolling
   padding: 1rem 1.5rem;
   white-space: pre; }
 

--- a/_scss/skeleton.scss
+++ b/_scss/skeleton.scss
@@ -316,6 +316,7 @@ code {
   border-radius: 4px; }
 pre > code {
   display: block;
+	overflow: auto; // fix background color for code blocks with horizontal scrolling
   padding: 1rem 1.5rem;
   white-space: pre; }
 


### PR DESCRIPTION
Fixes https://github.com/defold/defold.github.io/issues/113

## Before (Manual)

https://defold.com/manuals/atlas/#creating-a-texture-resource-at-runtime

![image](https://github.com/defold/defold.github.io/assets/7230306/e2d23251-9857-409c-b2e9-27776d16af16)

## After (Manual)

![image](https://github.com/defold/defold.github.io/assets/7230306/03f2f1b7-d5dd-47a6-9635-e52052ebd4d5)

## Before (Examples)

https://defold.com/examples/animation/basic_tween/

![image](https://github.com/defold/defold.github.io/assets/7230306/8b16983a-5442-44c8-890b-fdea6a35990c)

## After (Examples)

<img width="631" alt="image" src="https://github.com/defold/defold.github.io/assets/7230306/f9a7c2c8-0ecd-469d-91cb-570ebc96977b">
