### PR TITLE
Remove from showcase

### DIFF
--- a/_layouts/api.html
+++ b/_layouts/api.html
@@ -6,10 +6,11 @@ layout: base
 {%- assign indices = unsortedindices | sort: "namespace" -%}
 {%- assign branches = site.data.branchindex -%}
 {%- assign types = indices | map: "type" | uniq -%}
+{% assign clean_ref = page.ref | remove: '.' %}
 {%- if page.type == "extension" -%}
-	{%- assign ref = site.data.extensions[page.ref] -%}
+	{%- assign ref = site.data.extensions[clean_ref] -%}
 {%- else -%}
-	{%- assign ref = site.data.ref[page.branch][page.ref] -%}
+	{%- assign ref = site.data.ref[page.branch][clean_ref] -%}
 {%- endif -%}
 
 {%- if page.url contains branch -%}


### PR DESCRIPTION
`b2d.body.json` has key `b2dbody` in `site.data.ref[page.branch]`, so we should prepare key before using it