### PR TITLE
Make API reference constant section compact, renamings

### DIFF
--- a/_includes/api.html
+++ b/_includes/api.html
@@ -12,7 +12,7 @@
 {%- if functions.size > 0 -%}
 <table class="compact">
 	<tr>
-		<th>FUNCTION</th>
+		<th>FUNCTIONS</th>
 		<th></th>
 	</tr>
 	{%- for function in functions -%}
@@ -27,7 +27,7 @@
 {%- if variables.size > 0 -%}
 <table class="compact">
 	<tr>
-		<th>CONSTANT</th>
+		<th>CONSTANTS</th>
 		<th></th>
 	</tr>
 	{%- for variable in variables -%}
@@ -57,7 +57,7 @@
 {%- if messages.size > 0 -%}
 <table class="compact">
 	<tr>
-		<th>MESSAGE</th>
+		<th>MESSAGES</th>
 		<th></th>
 	</tr>
 	{%- for message in messages -%}
@@ -142,14 +142,14 @@
 <h2>Constants</h2>
 	{%- for variable in variables -%}
 	{% include ref_anchor_target.html element=variable %}
-	<h4>{{ variable.name }}<a href="#{% include ref_anchorlink.html element=variable %}" class="anchor-link"/></a></h4>
-	<p>{{ variable.description }}</p>
+	<h5 class="compact">{{ variable.name }}<a href="#{% include ref_anchorlink.html element=variable %}" class="anchor-link"/></a></h5 class="compact">
+	<p class="compact">{{ variable.description }}</p>
 
 	{%- if variable.parameters.size > 0 -%}
 	{% include api_parameters.html parameters=variable.parameters %}
 	{%- endif -%}
-
-	<hr/>
+	
+	{% if forloop.last == false %}<hr class="compact"/>{% else %}<hr/>{% endif %}
 	{%- endfor -%}
 {%- endif -%}
 

--- a/_scss/defold.scss
+++ b/_scss/defold.scss
@@ -403,6 +403,19 @@ mark {
 	margin-block-end: 0;
 }
 
+hr.compact {
+	margin-top: 1rem;
+	margin-bottom: 1.5rem;
+}
+
+h5.compact {
+	margin-bottom: 5px;
+}
+
+p.compact {
+	margin-bottom: 1.5rem;
+}
+
 /*******************************************************************************
 * Page setup (to keep footer always at the bottom)
 * Used in _layouts/base.html


### PR DESCRIPTION
Fixes #98 

## Changes

- make constants section more compact (change h4 to h5, reduce vertical margins)
- rename "Constant" section to "Constants"
- rename "Function" section to "Functions"
- rename "Message" section to "Messages"

## Before

<img src="https://github.com/user-attachments/assets/f3440819-2f6a-42b5-85ed-af7426b51a40" height="300"/>
<br><br>
<img src="https://github.com/user-attachments/assets/2646a629-2c03-40a4-b8e0-f75413855f9a" height="300"/>

## After

<img src="https://github.com/user-attachments/assets/c0984ff3-3082-4eab-9e6a-634cc426b09a" height="300"/>
<br><br>
<img src="https://github.com/user-attachments/assets/26b2fe6f-2565-4b94-95bc-056dcfc89fe2" height="300"/>
