### PR TITLE
Add support for generating llms-full.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@
 
 # Node is used for Lunr.js, used when generating the search index
 node_modules
+
+# `llms-full.txt` temporary files
+/_llms


### PR DESCRIPTION
This PR adds the generation of the llms-full.txt file, which contains all Defold documentation in a single page in the Markdown format. (almost all of it - the next huge step is to add /ref/ to the file)

So:
1) in `update.py` a step is added to process temporary files to the `_llms` folder
2) The `_llms` folder is added to gitignore and ignored by Jekyll because of the underscore. This path is used because it is convenient to see the result of the script how the files are converted.
3) in `update.py` the files are assembled into one big `llms-full.txt`. In this file all references are processed so that they are absolute. This is necessary so that the file can be viewed outside the context of the site, as one large convenient document.

This PR only adds `llms-full.txt`, without `llms.txt` (which is actually a collection of links and requires all pages on the site to have .md format as well, in addition to the finished html). LLM is evolving very quickly and from my research everyone is now using one big `llms-full.txt` file at once for query context for AI.

The format of `llms-full.txt` is based on https://duckdb.org/duckdb-docs.md, as the best reference for that filetype.

Fixes https://github.com/defold/doc/issues/522