### PR TITLE
Improve sidenote about community translations

### DIFF
--- a/_layouts/manual.html
+++ b/_layouts/manual.html
@@ -69,7 +69,9 @@ layout: page
 			<div class="columns eight manual">
 				{%- if page.language != "en" -%}
 				{%- capture urlprefix -%}/{{ language.urlprefix }}/{%- endcapture -%}
-				<p><a href="{{ page.url | replace: urlprefix, "/" }}">Read this manual in English</a></p>
+				<div class="sidenote">
+					<p>This translation is community contributed and may not be up to date. We only maintain the English version of the documentation. <a href="{{ page.url | replace: urlprefix, "/" }}">Read this manual in English</a></p>
+				</div>
 				{%- endif -%}
 				{% include anchor_headings.html html=content anchorClass="anchor-link" %}
 			</div>


### PR DESCRIPTION
Today, a co-worker pointed me to a non-English version of the documentation as the only correct one, so I thought it would be good to make it clear that the non-English version might not be up to date 🙌

![image](https://github.com/user-attachments/assets/6d8e640f-94fb-4a4d-bd6d-42accee821b3)
