### PR TITLE
If an example has no icon, use the first image from the md file as an icon

### DIFF
--- a/update.py
+++ b/update.py
@@ -816,6 +816,20 @@ def process_examples(download = False):
                     image_path = "https://www.defold.com/examples/%s/%s" % (fm["path"], fm["thumbnail"])
                     fm["opengraph_image"] = image_path
                     fm["twitter_image"] = image_path
+                else:
+                    # Try to find the first image in the markdown content
+                    content = read_as_string(md_file)
+                    # Look for markdown image syntax: ![alt](image.ext)
+                    import re
+                    image_match = re.search(r'!\[.*?\]\(([^)]+\.(png|jpg|jpeg|gif|webp))\)', content)
+                    if image_match:
+                        first_image = image_match.group(1)
+                        # Check if image exists in the example directory
+                        if os.path.exists(os.path.join(example_src_dir, first_image)):
+                            fm["thumbnail"] = first_image
+                            image_path = "https://www.defold.com/examples/%s/%s" % (fm["path"], first_image)
+                            fm["opengraph_image"] = image_path
+                            fm["twitter_image"] = image_path
                 examplesindex.append(fm)
                 replace_frontmatter(md_file, fm)
 

--- a/update.py
+++ b/update.py
@@ -820,7 +820,6 @@ def process_examples(download = False):
                     # Try to find the first image in the markdown content
                     content = read_as_string(md_file)
                     # Look for markdown image syntax: ![alt](image.ext)
-                    import re
                     image_match = re.search(r'!\[.*?\]\(([^)]+\.(png|jpg|jpeg|gif|webp))\)', content)
                     if image_match:
                         first_image = image_match.group(1)


### PR DESCRIPTION
It's not a perfect solution, but it's better than no icon at all (temporary solution until we re-visit all the examples and make proper icons or/and videos):

<img width="2522" height="1700" alt="CleanShot 2025-09-03 at 21 25 05@2x" src="https://github.com/user-attachments/assets/0d667f57-72ef-4fe2-a08f-5ea6fecec7b7" />
<img width="2574" height="2390" alt="CleanShot 2025-09-03 at 21 25 13@2x" src="https://github.com/user-attachments/assets/e16c6372-34e4-490b-82c2-0787c70b9636" />
<img width="2630" height="2424" alt="CleanShot 2025-09-03 at 21 25 22@2x" src="https://github.com/user-attachments/assets/5c18d2e6-af17-4fea-a906-3bef30d9e2c5" />
<img width="2560" height="2384" alt="CleanShot 2025-09-03 at 21 25 34@2x" src="https://github.com/user-attachments/assets/a28c203f-76eb-4986-845f-12f43cc20d83" />
<img width="2566" height="2350" alt="CleanShot 2025-09-03 at 21 25 47@2x" src="https://github.com/user-attachments/assets/013dffc4-730b-48cd-953e-198ec3b1710e" />
