### PR TITLE
Improve kbd styling

### DIFF
--- a/_scss/normalize.scss
+++ b/_scss/normalize.scss
@@ -227,11 +227,23 @@ pre {
  */
 
 code,
-kbd,
 pre,
 samp {
   font-family: monospace, monospace;
   font-size: 1em;
+}
+
+/*
+ * Keyboard and input markers in markdown (<kbd></kbd>)
+ */
+kbd {
+  font-family: monospace, monospace;
+  font-size: 1em;
+  background-color: var(--darker);
+  border: 1px solid var(--grey);
+  border-bottom-width: 3px;
+  border-radius: 4px;
+  padding: 0.15em 0.5em;
 }
 
 /* Forms


### PR DESCRIPTION
Added border and bottom wider border, so that it looks more like a "key" cap, more like on other websites:

<img width="75" height="81" alt="Zrzut ekranu z 2025-11-26 22-04-18" src="https://github.com/user-attachments/assets/60f342dc-a8df-4cb5-af4f-46e77a50eda7" />

Fixes #180 