### PR TITLE
259 investigate donationpurchase buttons for assets portal

### DIFF
--- a/_includes/asset.html
+++ b/_includes/asset.html
@@ -2,6 +2,19 @@
 {%- capture thumb_src -%}{% include asset_thumbnail_url.html asset=asset %}{%- endcapture -%}
 {%- assign asset_tag_classes = asset.tags | join: "%%" | replace: " ", "" | split: "%%" | join: " " | downcase -%}
 {%- assign asset_tag_values = asset.tags | join: "%%" | replace: " ", "" | split: "%%" | join: "|" | downcase -%}
+{%- assign external_actions = asset.external_actions | default: empty -%}
+{%- assign external_action_badge = "" -%}
+{%- if external_actions.size > 0 -%}
+	{%- assign first_external_action = external_actions | first -%}
+	{%- assign first_external_action_type = first_external_action.type | default: "external" | downcase -%}
+	{%- if first_external_action_type == "buy" -%}
+		{%- assign external_action_badge = "Paid" -%}
+	{%- elsif first_external_action_type == "support" or first_external_action_type == "donate" or first_external_action_type == "sponsor" -%}
+		{%- assign external_action_badge = "Support" -%}
+	{%- else -%}
+		{%- assign external_action_badge = "Creator link" -%}
+	{%- endif -%}
+{%- endif -%}
 {%- capture asset_tag_summary -%}
 	{%- for tag in asset.tags -%}
 		{%- assign tag_slug = tag | downcase | remove: " " -%}
@@ -25,6 +38,12 @@
 				<span class="asset-card-stars">
 					{% include site_icon.html name="star" class="asset-card-stars-icon" %}
 					<span>{{ asset.stars }}</span>
+				</span>
+				{%- endif -%}
+				{%- if external_action_badge.size > 0 -%}
+				<span class="asset-card-external-action-badge">
+					{% include site_icon.html name="heart" class="asset-card-external-action-icon" %}
+					<span>{{ external_action_badge }}</span>
 				</span>
 				{%- endif -%}
 			</span>

--- a/_layouts/asset.html
+++ b/_layouts/asset.html
@@ -8,6 +8,7 @@ layout: page
 {%- capture thumb_src -%}{% include asset_thumbnail_url.html asset=asset %}{%- endcapture -%}
 {%- assign project_link = asset.project_url | default: "" -%}
 {%- assign website_link = asset.website_url | default: "" -%}
+{%- assign external_actions = asset.external_actions | default: empty -%}
 {%- assign primary_link = "" -%}
 {%- assign primary_link_text = "" -%}
 {%- assign primary_link_icon = "browser" -%}
@@ -64,7 +65,7 @@ layout: page
 	{%- endif -%}
 {%- endif -%}
 {%- assign has_action_cards = false -%}
-{%- if show_primary_link_card or learn_more_link.size > 0 or asset.forum_url.size > 0 or asset.asset_url.size > 0 -%}
+{%- if show_primary_link_card or learn_more_link.size > 0 or asset.forum_url.size > 0 or external_actions.size > 0 or asset.asset_url.size > 0 -%}
 	{%- assign has_action_cards = true -%}
 {%- endif -%}
 {%- assign has_release_panel = false -%}
@@ -224,6 +225,37 @@ layout: page
 					</a>
 					{%- endif -%}
 
+					{%- if external_actions.size > 0 -%}
+						{%- for action in external_actions -%}
+							{%- assign action_type = action.type | default: "external" | downcase -%}
+							{%- assign action_label = action.label | default: "External creator link" -%}
+							{%- assign action_url = action.url | default: "" -%}
+							{%- if action_url.size > 0 -%}
+					<a class="page-route-card asset-detail-action-card asset-detail-external-action-card" href="{{ action_url }}" target="_blank" rel="noopener nofollow sponsored">
+						<span class="page-route-card-icon" aria-hidden="true">
+								{%- if action_type == "buy" -%}
+							{% include site_icon.html name="credit-card" %}
+								{%- elsif action_type == "support" or action_type == "donate" or action_type == "sponsor" -%}
+							{% include site_icon.html name="heart" %}
+								{%- else -%}
+							{% include site_icon.html name="link-external" %}
+								{%- endif -%}
+						</span>
+						<span class="page-route-card-copy">
+							<h3>{{ action_label }}</h3>
+								{%- if action_type == "buy" -%}
+							<p>Buy this asset on an external marketplace. ↗</p>
+								{%- elsif action_type == "support" or action_type == "donate" or action_type == "sponsor" -%}
+							<p>Support the creator on an external platform. ↗</p>
+								{%- else -%}
+							<p>Open an external creator link. ↗</p>
+								{%- endif -%}
+						</span>
+					</a>
+							{%- endif -%}
+						{%- endfor -%}
+					{%- endif -%}
+
 					{%- if asset.asset_url.size > 0 -%}
 					<a class="page-route-card asset-detail-action-card" href="{{ asset.asset_url }}" target="_blank" rel="noopener">
 						<span class="page-route-card-icon" aria-hidden="true">
@@ -236,6 +268,9 @@ layout: page
 					</a>
 					{%- endif -%}
 				</div>
+				{%- if external_actions.size > 0 -%}
+				<p class="asset-detail-external-action-note">External links are provided by the asset creator. Defold does not process payments, provide refunds, or control availability, pricing, licensing, or support on third-party platforms.</p>
+				{%- endif -%}
 				{%- endif -%}
 			</article>
 

--- a/_layouts/asset.html
+++ b/_layouts/asset.html
@@ -22,7 +22,7 @@ layout: page
 		{%- assign primary_link_text = "View Repository" -%}
 		{%- assign primary_link_description = "Open the project repository with all releases and instructions. ↗" -%}
 		{%- if project_link contains "github.com/" -%}
-			{%- assign primary_link_icon_image = "/images/icons/icon-github.svg" -%}
+			{%- assign primary_link_icon_image = "/images/icons/GitHub-Mark-Light-32px@3x.png" -%}
 		{%- endif -%}
 	{%- else -%}
 		{%- assign primary_link_text = "Open project page" -%}

--- a/_scss/asset-detail.scss
+++ b/_scss/asset-detail.scss
@@ -122,6 +122,18 @@
 	font-size: 36.86px;
 }
 
+.asset-detail-external-action-card {
+	--page-route-card-tint: rgba(239, 90, 91, 0.12);
+}
+
+.asset-detail-external-action-note {
+	max-width: 64rem;
+	margin: 1rem 0 0;
+	color: rgba(255, 255, 255, 0.66);
+	font-size: 0.96rem;
+	line-height: 1.5;
+}
+
 .asset-copy-button {
 	min-height: 3.5rem;
 }
@@ -387,6 +399,10 @@
 	.page-detail-main p,
 	.asset-detail-summary {
 		color: rgba(20, 24, 28, 0.82);
+	}
+
+	.asset-detail-external-action-note {
+		color: rgba(20, 24, 28, 0.64);
 	}
 
 	.asset-detail-action-card .page-route-card-icon img {

--- a/_scss/defold.scss
+++ b/_scss/defold.scss
@@ -3927,12 +3927,14 @@ ul.page-checklist-negative li:before {
 	display: flex;
 	align-items: flex-start;
 	justify-content: space-between;
+	flex-wrap: wrap;
 	gap: 0.95rem;
 	width: 100%;
 }
 
 .asset-card-title-group {
 	display: grid;
+	flex: 1 1 13rem;
 	gap: 0.32rem;
 	min-width: 0;
 }
@@ -3982,6 +3984,43 @@ ul.page-checklist-negative li:before {
 }
 
 .asset-card-stars-icon .octicon svg {
+	display: block;
+	padding-top: 0;
+	padding-right: 0;
+}
+
+.asset-card-external-action-badge {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.42rem;
+	flex: 0 0 auto;
+	max-width: 100%;
+	padding: 0.36rem 0.68rem;
+	border: 1px solid rgba(255, 255, 255, 0.1);
+	border-radius: 999px;
+	background: rgba(239, 90, 91, 0.14);
+	color: rgba(255, 255, 255, 0.84);
+	font-size: 1.01rem;
+	font-weight: 700;
+	line-height: 0.95;
+}
+
+.asset-card-external-action-icon {
+	width: 1.08em;
+	height: 1.08em;
+	font-size: 1.01rem;
+	color: rgba(255, 255, 255, 0.92);
+}
+
+.asset-card-external-action-icon .octicon {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	width: 100%;
+	height: 100%;
+}
+
+.asset-card-external-action-icon .octicon svg {
 	display: block;
 	padding-top: 0;
 	padding-right: 0;

--- a/submit_asset.html
+++ b/submit_asset.html
@@ -30,6 +30,22 @@ stylesheets:
 		});
 
 		var name = document.getElementById("asset_name").value;
+		var externalActions = [];
+		var externalActionType = document.getElementById("asset_external_action_type").value;
+		var externalActionLabel = document.getElementById("asset_external_action_label").value.trim();
+		var externalActionUrl = document.getElementById("asset_external_action_url").value.trim();
+		if (externalActionLabel || externalActionUrl) {
+			if (!externalActionLabel || !externalActionUrl) {
+				alert("External action label and URL are both required when adding a creator action.");
+				return;
+			}
+			externalActions.push({
+				type: externalActionType,
+				label: externalActionLabel,
+				url: externalActionUrl
+			});
+		}
+
 		var asset = {
 			name: name,
 			description: document.getElementById("asset_description").value,
@@ -46,6 +62,9 @@ stylesheets:
 				thumb: ""
 			}
 		};
+		if (externalActions.length > 0) {
+			asset.external_actions = externalActions;
+		}
 
 		var instructions = "Please attach two images on GitHub if possible: " + name + "-hero.[png|jpg] (max 2400x666) and " + name + "-thumb.[png|jpg] (max 580x380).";
 		var url = "https://github.com/defold/asset-portal/issues/new"
@@ -103,6 +122,27 @@ stylesheets:
 					<div class="submit-form-field">
 						<label for="asset_license">License</label>
 						<input id="asset_license" type="text" name="license" required>
+					</div>
+
+					<div class="submit-form-field">
+						<label for="asset_external_action_type">Creator action type (optional)</label>
+						<select id="asset_external_action_type" name="external_action_type">
+							<option value="support">Support</option>
+							<option value="buy">Buy</option>
+							<option value="donate">Donate</option>
+							<option value="sponsor">Sponsor</option>
+							<option value="external">External link</option>
+						</select>
+					</div>
+
+					<div class="submit-form-field">
+						<label for="asset_external_action_label">Creator action label (optional)</label>
+						<input id="asset_external_action_label" type="text" name="external_action_label" maxlength="50" placeholder="Support on Ko-fi">
+					</div>
+
+					<div class="submit-form-field submit-form-field-full">
+						<label for="asset_external_action_url">Creator action URL (optional)</label>
+						<input id="asset_external_action_url" type="url" name="external_action_url" placeholder="https://ko-fi.com/creator">
 					</div>
 
 					<fieldset class="submit-form-field submit-form-field-full submit-form-fieldset">

--- a/update.py
+++ b/update.py
@@ -1231,6 +1231,82 @@ def validate_asset_tags(asset_source_dir):
             details += "\n... and {} more".format(len(unknown_tags) - 50)
         raise ValueError("Unknown asset tags:\n{}".format(details))
 
+ASSET_EXTERNAL_ACTION_TYPES = set(["buy", "support", "donate", "sponsor", "external"])
+ASSET_EXTERNAL_ACTION_HOSTS = [
+    "itch.io",
+    "patreon.com",
+    "ko-fi.com",
+    "paypal.com",
+    "paypal.me",
+    "buy.stripe.com",
+    "checkout.stripe.com",
+    "gumroad.com",
+    "github.com",
+    "opencollective.com",
+]
+ASSET_EXTERNAL_ACTION_BLOCKED_LABELS = [
+    "official defold purchase",
+    "official defold checkout",
+    "defold checkout",
+]
+
+def asset_external_action_host_allowed(host):
+    host = (host or "").lower().rstrip(".")
+    if host.startswith("www."):
+        host = host[4:]
+    for allowed_host in ASSET_EXTERNAL_ACTION_HOSTS:
+        if host == allowed_host or host.endswith("." + allowed_host):
+            return True
+    return False
+
+def validate_asset_external_actions(asset_source_dir):
+    errors = []
+    for filename in find_files(asset_source_dir, "*.json"):
+        asset_id = os.path.basename(filename).replace(".json", "")
+        asset = read_as_json(filename)
+        external_actions = asset.get("external_actions", [])
+
+        if external_actions in (None, ""):
+            continue
+        if not isinstance(external_actions, list):
+            errors.append("{}: external_actions must be an array".format(asset_id))
+            continue
+        if len(external_actions) > 3:
+            errors.append("{}: external_actions can contain at most 3 entries".format(asset_id))
+
+        for index, action in enumerate(external_actions):
+            label = "{} external_actions[{}]".format(asset_id, index)
+            if not isinstance(action, dict):
+                errors.append("{} must be an object".format(label))
+                continue
+
+            action_type = (action.get("type") or "external").lower()
+            if action_type not in ASSET_EXTERNAL_ACTION_TYPES:
+                errors.append("{} has unsupported type: {}".format(label, action.get("type")))
+
+            action_label = (action.get("label") or "").strip()
+            if not action_label:
+                errors.append("{} must have a label".format(label))
+            elif len(action_label) > 50:
+                errors.append("{} label must be 50 characters or fewer".format(label))
+            elif action_label.lower() in ASSET_EXTERNAL_ACTION_BLOCKED_LABELS:
+                errors.append("{} label is misleading: {}".format(label, action_label))
+
+            action_url = (action.get("url") or "").strip()
+            parsed_url = urlparse(action_url)
+            if parsed_url.scheme != "https":
+                errors.append("{} URL must use https://".format(label))
+            elif not parsed_url.netloc:
+                errors.append("{} URL must include a host".format(label))
+            elif not asset_external_action_host_allowed(parsed_url.hostname):
+                errors.append("{} URL host is not allowlisted: {}".format(label, parsed_url.hostname))
+
+    if errors:
+        details = "\n".join(errors[:50])
+        if len(errors) > 50:
+            details += "\n... and {} more".format(len(errors) - 50)
+        raise ValueError("Invalid asset external_actions:\n{}".format(details))
+
 def fix_platforms_case(platforms):
     if platforms:
         if platforms[0].lower() == "*":
@@ -1251,6 +1327,7 @@ def fix_platforms_case(platforms):
 def process_assets(tmp_dir):
     asset_source_dir = os.path.join(tmp_dir, "asset-portal-master", "assets")
     validate_asset_tags(asset_source_dir)
+    validate_asset_external_actions(asset_source_dir)
 
     # Jekyll assets collection
     asset_collection_dir = "assets"


### PR DESCRIPTION
Added a button, when external_actions is defined for an asset:

<img width="1338" height="883" alt="image" src="https://github.com/user-attachments/assets/cd4d555d-b19f-4a58-98b5-037e8eface63" />

Also fixes #311 from asset-portal

