### PR TITLE
Reuse showcase images during site builds

### DIFF
--- a/.github/workflows/build_site.yml
+++ b/.github/workflows/build_site.yml
@@ -46,9 +46,6 @@ jobs:
           bundle exec ruby tests/test_api_lua_v2_rendering.rb
           python -m unittest discover -s tests
 
-      - name: Download showcase images
-        run: python update.py --download game-images
-
       - name: Build Jekyll site
         run: |
           python -m scripts.strip_asmjs

--- a/.github/workflows/update_site.yml
+++ b/.github/workflows/update_site.yml
@@ -94,10 +94,6 @@ jobs:
         name: Update extension
         run: python update.py --download --extension "$ACTION" extensions refdoc
 
-      - if: env.ACTION != 'games-showcase' && env.ACTION != 'all'
-        name: Download showcase images
-        run: python update.py --download game-images
-
       - name: Build Jekyll site
         run: |
           python -m scripts.strip_asmjs

--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,6 @@
 /*.zip
 /bob_*.jar
 
-# Downloaded from the games-showcase source of truth before each site build
-/images/games/
-
 # General excludes
 /design
 
@@ -24,8 +21,7 @@ vendor/bundle/
 # `llms-full.txt` temporary files
 /_llms
 
-/__pycache__
-/scripts/__pycache__
-*.cpython-311.pyc
+__pycache__/
+*.py[cod]
 
 .venv/*

--- a/README.md
+++ b/README.md
@@ -54,10 +54,9 @@ The script accepts the following commands:
 * `examples` - Import examples from github.com/defold/examples
 * `asset-portal` - Import Asset Portal content from github.com/defold/asset-portal
 * `games-showcase` - Import Showcase content from github.com/defold/games-showcase
-* `game-images` - Download only the website-ready Showcase images for a local or CI build
 * `commit` - Commit changes to GitHub (for CI use)
 
-The Showcase source of truth is `defold/games-showcase`. `_data/games.json` and `_data/showcase_featured_full.json` are generated snapshots. Game images are versioned only in `games-showcase`; `images/games` is ignored here and downloaded before every CI build. Run `python3 update.py --download game-images` before a direct local Jekyll build, or run the full `games-showcase` import when testing data changes.
+The Showcase source of truth is `defold/games-showcase`. `_data/games.json`, `_data/showcase_featured_full.json`, and `images/games` are committed snapshots, like the Asset Portal data and images. Ordinary site builds use these snapshots without downloading showcase content. Showcase content changes trigger the `games-showcase` update; an explicit `all` update also refreshes it. Run `python3 update.py --download games-showcase` to refresh locally. This downloads the upstream archive, copies only new or changed referenced images, removes obsolete image files, and updates the catalog and featured list together. Unchanged images are reused without recompression.
 
 # HOW TO TEST THE SITE LOCALLY
 It is recommended that you generate and test the site locally before pushing the changes to the repository. You generate and test the site locally by running `serve.sh`.
@@ -182,7 +181,7 @@ The script is also triggered once every hour to update the asset portal star cou
 
 * [Update site](https://github.com/defold/defold.github.io/blob/master/.github/workflows/update_site.yml) - on change in external repository (triggered using the repository_dispatch event)
   * Asset-portal - Triggered from [asset-portal workflow](https://github.com/defold/asset-portal/blob/master/.github/workflows/trigger-site-rebuild.yml) on change.
-  * Games-showcase - Triggered from the [games-showcase publish workflow](https://github.com/defold/games-showcase/blob/master/.github/workflows/publish.yml) after validated changes reach `master`.
+  * Games-showcase - Triggered from the [games-showcase publish workflow](https://github.com/defold/games-showcase/blob/master/.github/workflows/publish.yml) after validated game data, image, order, or featured-list changes reach `master`, or when manually dispatched.
   * Docs (manuals, tutorials, faq) - Triggered from [doc workflow](https://github.com/defold/doc/blob/master/.github/workflows/trigger-site-rebuild.yml) on change.
   * Docs (examples) - Triggered from [examples workflow](https://github.com/defold/examples/blob/master/.github/workflows/trigger-site-rebuild.yml) on change.
   * Codepad - Triggered from [codepad workflow](https://github.com/defold/codepad/blob/master/.github/workflows/trigger-site-rebuild.yml) on change.

--- a/tests/test_update_imports.py
+++ b/tests/test_update_imports.py
@@ -3,9 +3,13 @@ import contextlib
 import io
 import json
 import os
+import shutil
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
+
+import yaml
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -22,7 +26,24 @@ def function_source(name: str) -> str:
     return ast.get_source_segment(UPDATE_SOURCE, node)
 
 
-def load_game_importer(games_json: Path, featured_json: Path, copy_calls: list):
+def load_image_copier():
+    namespace = {"os": os, "Path": Path, "shutil": shutil}
+    for name in ("games_showcase_root", "copy_game_images"):
+        exec(function_source(name), namespace)
+    return namespace["copy_game_images"]
+
+
+@contextlib.contextmanager
+def working_directory(path):
+    previous = Path.cwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous)
+
+
+def load_game_importer(games_json: Path, featured_json: Path):
     def find_files(root_dir, pattern):
         return sorted(str(path) for path in Path(root_dir).rglob(pattern))
 
@@ -40,7 +61,7 @@ def load_game_importer(games_json: Path, featured_json: Path, copy_calls: list):
         "find_files": find_files,
         "read_as_json": read_as_json,
         "write_as_json": write_as_json,
-        "copy_game_images": lambda tmp_dir: copy_calls.append(Path(tmp_dir)),
+        "copy_game_images": load_image_copier(),
         "GAMES_JSON": str(games_json),
         "SHOWCASE_FEATURED_FULL_JSON": str(featured_json),
     }
@@ -98,24 +119,25 @@ class UpdateImportBoundaryTests(unittest.TestCase):
         self.assertLess(build, pagefind)
         self.assertLess(pagefind, commit)
 
-    def test_ci_downloads_showcase_images_before_each_build(self):
+    def test_ci_refreshes_showcase_only_on_explicit_update(self):
         build_workflow = (ROOT / ".github/workflows/build_site.yml").read_text(
             encoding="utf-8"
         )
-        install = build_workflow.index("name: Install Python dependencies")
-        download = build_workflow.index("name: Download showcase images")
-        self.assertIn("requests", build_workflow[install:download])
-        self.assertIn("pyyaml", build_workflow[install:download])
-        self.assertLess(
-            download,
-            build_workflow.index("name: Build Jekyll site"),
-        )
+        self.assertNotIn("--download", build_workflow)
 
         update_workflow = (ROOT / ".github/workflows/update_site.yml").read_text(
             encoding="utf-8"
         )
-        self.assertIn("python update.py --download games-showcase", update_workflow)
-        self.assertIn("python update.py --download game-images", update_workflow)
+        steps = yaml.safe_load(update_workflow)["jobs"]["update_site"]["steps"]
+        self.assertEqual(
+            [step for step in steps if "game" in step.get("run", "")],
+            [{
+                "if": "env.ACTION == 'games-showcase'",
+                "name": "Update games",
+                "run": "python update.py --download games-showcase",
+            }],
+        )
+        self.assertNotIn("/images/games/", (ROOT / ".gitignore").read_text())
 
 
 class GamesShowcaseImportTests(unittest.TestCase):
@@ -147,14 +169,12 @@ class GamesShowcaseImportTests(unittest.TestCase):
         games_output = root / "output" / "games.json"
         featured_output = root / "output" / "featured.json"
         games_output.parent.mkdir()
-        copy_calls = []
-        importer = load_game_importer(games_output, featured_output, copy_calls)
-        with contextlib.redirect_stdout(io.StringIO()):
+        importer = load_game_importer(games_output, featured_output)
+        with working_directory(root), contextlib.redirect_stdout(io.StringIO()):
             importer(str(root))
         return (
             json.loads(games_output.read_text(encoding="utf-8")),
             json.loads(featured_output.read_text(encoding="utf-8")),
-            copy_calls,
         )
 
     def test_import_uses_upstream_order_featured_and_images(self):
@@ -162,20 +182,14 @@ class GamesShowcaseImportTests(unittest.TestCase):
             root = Path(temporary)
             self.make_source(root)
 
-            games, featured, copy_calls = self.run_import(root)
+            games, featured = self.run_import(root)
 
             self.assertEqual([game["id"] for game in games], ["beta", "alpha"])
             self.assertEqual(featured, ["alpha"])
-            self.assertEqual(copy_calls, [root])
-
-    def test_import_rejects_missing_referenced_image(self):
-        with tempfile.TemporaryDirectory() as temporary:
-            root = Path(temporary)
-            source = self.make_source(root)
-            (source / "games" / "images" / "alpha-full.webp").unlink()
-
-            with self.assertRaisesRegex(RuntimeError, "Missing showcase images"):
-                self.run_import(root)
+            self.assertEqual(
+                {path.name for path in (root / "images" / "games").iterdir()},
+                {"alpha-full.webp", "alpha-third.webp", "beta-half.webp"},
+            )
 
     def test_import_rejects_featured_list_different_from_full_games(self):
         with tempfile.TemporaryDirectory() as temporary:
@@ -185,6 +199,59 @@ class GamesShowcaseImportTests(unittest.TestCase):
 
             with self.assertRaisesRegex(RuntimeError, "Featured IDs must exactly match"):
                 self.run_import(root)
+
+    def test_images_copy_only_changed_references_and_prune_obsolete_files(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = self.make_source(root) / "games" / "images"
+            (source / "unused.webp").write_bytes(b"unused upstream image")
+            destination = root / "images" / "games"
+            destination.mkdir(parents=True)
+            (destination / "alpha-full.webp").write_bytes(b"fixture")
+            # Same size and timestamp must not hide changed image content.
+            (destination / "alpha-third.webp").write_bytes(b"changed")
+            timestamp = (source / "alpha-third.webp").stat().st_mtime_ns
+            os.utime(destination / "alpha-third.webp", ns=(timestamp, timestamp))
+            (destination / "obsolete.webp").write_bytes(b"old image")
+
+            with mock.patch.object(shutil, "copyfile", wraps=shutil.copyfile) as copy:
+                self.run_import(root)
+
+            self.assertEqual(
+                {Path(call.args[1]).name for call in copy.call_args_list},
+                {"alpha-third.webp", "beta-half.webp"},
+            )
+            self.assertEqual(
+                {path.name for path in destination.iterdir()},
+                {"alpha-full.webp", "alpha-third.webp", "beta-half.webp"},
+            )
+            for path in destination.iterdir():
+                self.assertEqual(path.read_bytes(), b"fixture")
+
+            with working_directory(root), mock.patch.object(shutil, "copyfile") as copy:
+                load_image_copier()(str(root), {path.name for path in destination.iterdir()})
+            copy.assert_not_called()
+
+    def test_missing_image_does_not_change_existing_snapshots(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            source = self.make_source(root)
+            self.run_import(root)
+            snapshots = {
+                path: path.read_bytes()
+                for directory in (root / "output", root / "images")
+                for path in directory.rglob("*") if path.is_file()
+            }
+            (source / "games" / "images" / "alpha-third.webp").unlink()
+            (source / "games" / "images" / "alpha-full.webp").write_bytes(b"new")
+            importer = load_game_importer(
+                root / "output" / "games.json", root / "output" / "featured.json"
+            )
+            with working_directory(root), contextlib.redirect_stdout(io.StringIO()):
+                with self.assertRaisesRegex(RuntimeError, "Missing showcase images"):
+                    importer(str(root))
+            for path, content in snapshots.items():
+                self.assertEqual(path.read_bytes(), content)
 
 
 if __name__ == "__main__":

--- a/update.py
+++ b/update.py
@@ -8,6 +8,7 @@ import sys
 import shutil
 import fnmatch
 import json
+from pathlib import Path
 import tempfile
 import re
 import subprocess
@@ -1464,11 +1465,28 @@ def games_showcase_root(tmp_dir):
     return os.path.join(tmp_dir, "games-showcase-master")
 
 
-def copy_game_images(tmp_dir):
-    source_dir = os.path.join(games_showcase_root(tmp_dir), "games", "images")
-    if not os.path.isdir(source_dir):
+def copy_game_images(tmp_dir, referenced_images):
+    source_dir = Path(games_showcase_root(tmp_dir)) / "games" / "images"
+    if not source_dir.is_dir():
         raise RuntimeError("games-showcase archive has no games/images directory")
-    rmcopytree(source_dir, os.path.join("images", "games"))
+
+    for image in referenced_images:
+        if Path(image).name != image:
+            raise RuntimeError("Showcase image must be a filename: {}".format(image))
+    missing_images = sorted(image for image in referenced_images if not (source_dir / image).is_file())
+    if missing_images:
+        raise RuntimeError("Missing showcase images: {}".format(", ".join(missing_images)))
+
+    image_dir = Path("images") / "games"
+    image_dir.mkdir(parents=True, exist_ok=True)
+    for image in sorted(referenced_images):
+        source = source_dir / image
+        destination = image_dir / image
+        if not destination.is_file() or destination.read_bytes() != source.read_bytes():
+            shutil.copyfile(source, destination)
+    for image in image_dir.iterdir():
+        if image.is_file() and image.name not in referenced_images:
+            image.unlink()
 
 
 def process_games(tmp_dir):
@@ -1509,19 +1527,11 @@ def process_games(tmp_dir):
             if image:
                 referenced_images.add(image)
 
-    source_image_dir = os.path.join(source_games_dir, "images")
-    missing_images = sorted(
-        image for image in referenced_images
-        if not os.path.isfile(os.path.join(source_image_dir, image))
-    )
-    if missing_images:
-        raise RuntimeError("Missing showcase images: {}".format(", ".join(missing_images)))
-
     full_ids = {game["id"] for game in games if game.get("showcase") == "full"}
     if set(featured_full) != full_ids:
         raise RuntimeError("Featured IDs must exactly match games with showcase=full")
 
-    copy_game_images(tmp_dir)
+    copy_game_images(tmp_dir, referenced_images)
     write_as_json(GAMES_JSON, games, False)
     write_as_json(SHOWCASE_FEATURED_FULL_JSON, featured_full, False)
 
@@ -1555,23 +1565,6 @@ def process_games_showcase(download = False):
         shutil.copyfile(GAMESSHOWCASE_ZIP, os.path.join(tmp_dir, GAMESSHOWCASE_ZIP))
         unzip(os.path.join(tmp_dir, GAMESSHOWCASE_ZIP), tmp_dir)
         process_games(tmp_dir)
-
-
-def process_game_images(download = False):
-    if download:
-        if os.path.exists(GAMESSHOWCASE_ZIP):
-            os.remove(GAMESSHOWCASE_ZIP)
-        download_file("https://github.com/defold/games-showcase/archive/master.zip", ".", GAMESSHOWCASE_ZIP)
-
-    if not os.path.exists(GAMESSHOWCASE_ZIP):
-        print("File {} does not exist".format(GAMESSHOWCASE_ZIP))
-        sys.exit(1)
-
-    with tmpdir() as tmp_dir:
-        shutil.copyfile(GAMESSHOWCASE_ZIP, os.path.join(tmp_dir, GAMESSHOWCASE_ZIP))
-        unzip(os.path.join(tmp_dir, GAMESSHOWCASE_ZIP), tmp_dir)
-        copy_game_images(tmp_dir)
-
 
 
 def process_refdoc(download = False):
@@ -1819,7 +1812,7 @@ def commit_changes():
             subprocess.run([ "git", "fetch", "origin", "master" ], check=True)
 
 
-ALL_COMMANDS = [ "all", "help", "docs", "refdoc", "asset-portal", "games-showcase", "game-images", "examples", "codepad", "commit", "extensions" ]
+ALL_COMMANDS = [ "all", "help", "docs", "refdoc", "asset-portal", "games-showcase", "examples", "codepad", "commit", "extensions" ]
 ALL_COMMANDS.sort()
 
 parser = ArgumentParser()
@@ -1837,7 +1830,6 @@ docs = Process the docs (manuals, tutorials and faq)
 refdoc = Process the API reference
 asset-portal = Process the assets list (from asset-portal)
 games-showcase = Process the games list (from games-showcase)
-game-images = Download website-ready game images without regenerating game data
 examples = Build the examples
 codepad = Build the Defold CodePad
 commit = Commit changed files
@@ -1854,8 +1846,6 @@ if "all" in args.commands:
     # Publishing is deliberately separate: CI validates the complete generated
     # site before invoking the commit command.
     commands.remove("commit")
-    # games-showcase already imports the images as part of the full data refresh.
-    commands.remove("game-images")
     args.commands = commands
 
 for command in args.commands:
@@ -1878,8 +1868,6 @@ for command in args.commands:
         process_asset_portal(download = args.download)
     elif command == "games-showcase":
         process_games_showcase(download = args.download)
-    elif command == "game-images":
-        process_game_images(download = args.download)
     elif command == "codepad":
         process_codepad(download = args.download)
     elif command == "commit":


### PR DESCRIPTION
Matching back to the Asset Portal workflow. Refresh images together with showcase data, copy only new or changed referenced files, and remove obsolete copies. Remove the standalone image download command and update tests and documentation.